### PR TITLE
Prevent "Invalid <Link> with <a> child." error

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -11,8 +11,8 @@ export default function Hero({ title, description }: Props) {
       <div className="hero-content">
         <div className="max-w-md text-center">
           <h1 className="pb-5 text-3xl font-bold text-stone-900">
-            <Link passHref={true} href="/">
-              <a className="hover:underline hover:cursor-pointer">{title}</a>
+            <Link passHref={true} href="/" className="hover:underline hover:cursor-pointer">
+              {title}
             </Link>
           </h1>
           <p className="text-lg text-stone-800">{description}</p>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -11,8 +11,11 @@ export default function Navbar({ title, repo, twitter }: Props) {
   return (
     <header className="sticky top-0 left-0 z-20 bg-white opacity-90 navbar">
       <div className="navbar-start">
-        <Link passHref={true} href="/">
-          <a className="text-stone-900 normal-case btn btn-ghost">{title}</a>
+        <Link
+          passHref={true}
+          href="/"
+          className="text-stone-900 normal-case btn btn-ghost">
+          {title}
         </Link>
       </div>
       <div className="navbar-end">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -77,8 +77,11 @@ function HomePost({ title, slug, created, excerpt }: Post) {
   return (
     <div className="py-5 pr-4 border-b-2">
       <h2 className="pb-5 pl-4 text-2xl font-bold text-stone-900">
-        <Link passHref={true} href={`/post/${slug}`}>
-          <a className="hover:underline hover:cursor-pointer">{title}</a>
+        <Link
+          passHref={true}
+          href={`/post/${slug}`}
+          className="hover:underline hover:cursor-pointer">
+          {title}
         </Link>
       </h2>
       <div
@@ -86,8 +89,11 @@ function HomePost({ title, slug, created, excerpt }: Post) {
         dangerouslySetInnerHTML={{ __html: excerpt }}
       />
       <div className="pb-5 pl-8 text-center">
-        <Link passHref={true} href={`/post/${slug}`}>
-          <a className="normal-case btn btn-ghost btn-block">この記事を読む</a>
+        <Link
+          passHref={true}
+          href={`/post/${slug}`}
+          className="normal-case btn btn-ghost btn-block">
+          この記事を読む
         </Link>
       </div>
       <div className="pl-4 text-sm text-right text-stone-800">{created}</div>


### PR DESCRIPTION
`npx @next/codemod new-link .` is applied.